### PR TITLE
イベントページに他サイト作成依頼の案内を追加

### DIFF
--- a/src/routes/events/[event_id]/+page.svelte
+++ b/src/routes/events/[event_id]/+page.svelte
@@ -157,6 +157,10 @@
 
 <footer>
     <p>© 2025 X投稿ヘルパー | <a href="https://github.com/yonetty/x-post-helper" target="_blank">GitHub</a></p>
+    <p class="footer-info">
+        他のイベント用のX投稿ヘルパーサイトをご希望の場合は、
+        <a href="https://forms.gle/Q3k3ykvMeTthqbCD9" target="_blank">こちらのフォーム</a>よりお申し込みください。
+    </p>
 </footer>
 {:else}
 	<!-- データがない場合の表示（通常は発生しないはず） -->
@@ -302,6 +306,18 @@
         text-align: center;
         font-size: 14px;
         color: #657786;
+    }
+    .footer-info {
+        margin-top: 10px;
+        font-size: 13px;
+        line-height: 1.4;
+    }
+    .footer-info a {
+        color: #1da1f2;
+        text-decoration: none;
+    }
+    .footer-info a:hover {
+        text-decoration: underline;
     }
     /* クリアボタンのスタイルを調整 */
     .small-button {


### PR DESCRIPTION
## Summary
  - イベントページのフッターに、他のイベント用X投稿ヘルパーサイト作成依頼の案内を追加
  - 申請フォームへのリンクを含む案内文を追加し、他のイベント主催者への誘導を改善

  ## Changes
  - フッターに申請フォームへのリンクを含む案内文を追加
  - `.footer-info` クラスでスタイリングし視認性を向上
  - 既存のGitHubリンクとの調和を保ったデザイン

  ## Test plan
  - [x] ローカルでページが正しく表示されることを確認
  - [x] 追加したリンクが正しく動作することを確認
  - [x] レスポンシブデザインが保たれることを確認