### PR TITLE
feat: Google Analytics 4を実装

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,6 +5,15 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
+		
+		<!-- Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-EFFC4L3522"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+			gtag('config', 'G-EFFC4L3522');
+		</script>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/src/lib/event-data/bar.json
+++ b/src/lib/event-data/bar.json
@@ -1,0 +1,16 @@
+{
+  "eventId": "bar",
+  "eventName": "Bar",
+  "iconEmoji": "⚽️",
+  "mainHashtag": "#bar",
+  "tracks": [
+    {
+      "hashtag": "#bar_A",
+      "name": "A"
+    },
+    {
+      "hashtag": "#bar_B",
+      "name": "B"
+    }
+  ]
+}


### PR DESCRIPTION
- GA測定ID (G-EFFC4L3522) をapp.htmlに直接埋め込み
- 静的サイト生成時に全ページにGAタグが含まれるよう修正
- 不要な+layout.svelteのクライアントサイドGA実装を削除
- TypeScriptの型定義を追加